### PR TITLE
Remove pre-publish checklist from self-hosting GitHub Pages blog post…

### DIFF
--- a/src/content/blog/self-host-github-pages-custom-domain/index.mdx
+++ b/src/content/blog/self-host-github-pages-custom-domain/index.mdx
@@ -188,15 +188,3 @@ git branch -a
 If you maintain a dedicated publishing branch, pushes target that branch instead—but only do this if that matches how your Pages source is configured.
 
 ---
-
-## Pre-publish checklist
-
-- [ ] Frontmatter complete (`title`, `description`, `date`, `tags`, `authors`, `slug`, `updatedDate`).
-- [ ] `description` ~150–160 characters, English, no obvious typos.
-- [ ] A beginner can follow the main path end-to-end.
-- [ ] Branch section: one clear publishing source + common failure modes covered.
-- [ ] DNS section: apex vs subdomain clarified; link to GitHub docs for current record values.
-- [ ] HTTPS section: delays and DNS dependency explained.
-- [ ] No secrets, tokens, or sensitive real domains in examples.
-- [ ] External links to official documentation verified (no 404).
-- [ ] Local Astro build (`npm run build`) passes for the new content entry.


### PR DESCRIPTION
… for a cleaner presentation.